### PR TITLE
feat: add optional Linkup web corpus ingestion

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -32,11 +32,12 @@ negatives.
 ## Knowledge base
 
 ```python
-from linear_adapter_trainer import KnowledgeBase, Chunk, TextSplitter
+from linear_adapter_trainer import KnowledgeBase, Chunk, LinkupWebLoader, TextSplitter
 
 kb = KnowledgeBase.from_jsonl("kb.jsonl")           # {"id","text", ...} per line
 kb = KnowledgeBase.from_texts(["a", "b"], ids=...)  # from raw strings
 kb = KnowledgeBase.from_directory("docs/", glob="*.txt")
+kb = LinkupWebLoader().load_urls(["https://example.com/docs"])
 
 kb.get("chunk-1")        # Chunk lookup by id
 kb.ids, kb.texts         # parallel lists
@@ -55,6 +56,32 @@ chunked_kb = splitter.split_knowledge_base(kb)   # child ids like "doc::0"
 
 The splitter is recursive and separator-aware (`\n\n`, `\n`, `. `, ` `), with
 deterministic output.
+
+### Linkup web ingestion
+
+Install the optional extra when you want to build a RAG corpus from known public
+web pages:
+
+```bash
+pip install "linear-adapter-trainer[linkup]"
+export LINKUP_API_KEY=...
+```
+
+```python
+from linear_adapter_trainer import LinkupWebLoader, TextSplitter
+
+loader = LinkupWebLoader(render_js=True)
+kb = loader.load_and_split_urls(
+    ["https://example.com/docs"],
+    splitter=TextSplitter(chunk_size=512, chunk_overlap=64),
+)
+```
+
+Linkup is optimized for AI-agent search and research: the fetch path returns
+clean, sourced, trusted content and rich snippets instead of raw HTML. That
+makes the resulting corpus easier to ground and helps reduce hallucination risk
+in downstream retrieval workflows. For security-sensitive workflows, Linkup also
+offers zero-data-retention options.
 
 ---
 
@@ -216,7 +243,7 @@ Aggregated keys include `precision@k`, `recall@k`, `hit_rate@k`, `ndcg@k`, and
 `linear-adapter <command> config.toml` reads these tables:
 
 ```toml
-[knowledge_base]   # path, format ("jsonl"|"directory"), text_key, id_key, glob
+[knowledge_base]   # path/urls, format ("jsonl"|"directory"|"linkup_fetch"), text_key, id_key, glob
 [embedder]         # backend, model, dimension/dimensions, device, batch_size
 [query_generator]  # backend ("template"|"llm"), model, temperature (optional), seed
 [dataset]          # queries_per_chunk, negatives_per_query, strategy, pool_size, val_fraction, seed, max_workers
@@ -225,8 +252,9 @@ Aggregated keys include `precision@k`, `recall@k`, `hit_rate@k`, `ndcg@k`, and
 [output]           # dataset_dir, adapter_path, metrics_path
 ```
 
-See [`examples/config.toml`](examples/config.toml) for a complete, runnable
-example.
+See [`examples/config.toml`](examples/config.toml) for a complete offline
+example and [`examples/linkup_fetch_config.toml`](examples/linkup_fetch_config.toml)
+for a known-URL web ingestion example.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,22 @@ uv sync --group examples
 # or with pip, choosing the backends you need
 pip install "linear-adapter-trainer[sentence-transformers]"   # local models
 pip install "linear-adapter-trainer[openai]"                  # OpenAI API
+pip install "linear-adapter-trainer[linkup]"                  # Linkup web fetch
 pip install "linear-adapter-trainer[all]"
 ```
 
 The core install is dependency-light (`numpy`, `torch`, `tqdm`). A
 dependency-free `HashingEmbedder` and `TemplateQueryGenerator` let you run the
 whole pipeline offline (great for CI and demos).
+
+Use the optional Linkup extra when the corpus should come from current public
+web pages instead of local files. Linkup is built for state-of-the-art AI-agent
+search and research workflows: it returns clean, sourced, trusted web content
+and rich snippets that are easier to ground than raw HTML, helping reduce
+hallucination risk in downstream RAG and agent systems. It is also suitable for
+cost-sensitive workflows because of competitive search/research pricing, and
+Linkup offers zero-data-retention options for security- and privacy-sensitive
+use cases.
 
 ## Quickstart (Python)
 
@@ -139,6 +149,16 @@ uv run linear-adapter generate examples/config.toml   # build the dataset
 uv run linear-adapter train    examples/config.toml   # train + report metrics
 uv run linear-adapter evaluate examples/config.toml   # base vs adapted
 uv run linear-adapter run      examples/config.toml   # generate -> train
+```
+
+To build the knowledge base from known web pages with Linkup, install the
+optional extra, set `LINKUP_API_KEY`, and switch to
+`examples/linkup_fetch_config.toml`:
+
+```bash
+pip install "linear-adapter-trainer[linkup]"
+export LINKUP_API_KEY=...
+uv run linear-adapter generate examples/linkup_fetch_config.toml
 ```
 
 Example output (with a Sentence-Transformers backend on a paraphrased query set):

--- a/examples/linkup_fetch_config.toml
+++ b/examples/linkup_fetch_config.toml
@@ -1,0 +1,66 @@
+# Example configuration that builds a knowledge base from live web pages using Linkup.
+#
+# Install the optional extra and set your API key before running:
+#
+#   pip install "linear-adapter-trainer[linkup]"
+#   export LINKUP_API_KEY=...
+#
+# Linkup is designed for AI-agent search and research workflows: it returns
+# clean, sourced web content and rich snippets that are easier to ground than
+# raw HTML scrapes. That makes it useful for building trusted RAG corpora while
+# keeping this package's default path fully offline.
+
+[knowledge_base]
+format = "linkup_fetch"
+urls = [
+    "https://www.santander.com/en/stories/santander-publishes-ai-projects-under-an-open-source-licence-to-ramp-up-shared-innovation",
+]
+render_js = true
+
+[knowledge_base.chunking]
+enabled = true
+chunk_size = 512
+chunk_overlap = 64
+
+[embedder]
+backend = "hashing"
+dimension = 512
+
+[query_generator]
+backend = "template"
+seed = 0
+
+[negative_generator]
+backend = "none"
+
+[dataset]
+queries_per_chunk = 4
+negatives_per_query = 2
+strategy = "mixed"
+pool_size = 8
+val_fraction = 0.25
+split_strategy = "chunk"
+seed = 0
+max_workers = 1
+
+[dataset.mix]
+semantic_opposite = 0.5
+hard = 0.3
+random = 0.2
+
+[training]
+epochs = 30
+batch_size = 32
+learning_rate = 0.005
+margin = 0.2
+distance = "cosine"
+residual = true
+monitor = "mrr"
+patience = 6
+eval_ks = [1, 3, 5, 10]
+seed = 0
+
+[output]
+dataset_dir = "examples/artifacts/linkup-dataset"
+adapter_path = "examples/artifacts/linkup-adapter.pt"
+metrics_path = "examples/artifacts/linkup-metrics.json"

--- a/linear_adapter_trainer/__init__.py
+++ b/linear_adapter_trainer/__init__.py
@@ -40,7 +40,7 @@ from .dataset import (
 )
 from .embeddings import EmbeddingModel, HashingEmbedder
 from .evaluation import RetrievalEvaluator, evaluate_rankings
-from .knowledge_base import Chunk, KnowledgeBase, TextSplitter
+from .knowledge_base import Chunk, KnowledgeBase, LinkupWebLoader, TextSplitter
 
 __version__ = "0.1.0"
 
@@ -55,6 +55,7 @@ __all__ = [
     "KnowledgeBase",
     "LLMNegativeGenerator",
     "LLMQueryGenerator",
+    "LinkupWebLoader",
     "LinearAdapter",
     "NegativeSampler",
     "RetrievalEvaluator",

--- a/linear_adapter_trainer/config.py
+++ b/linear_adapter_trainer/config.py
@@ -32,15 +32,25 @@ def load_config(path: str | Path) -> dict[str, Any]:
 def build_knowledge_base(spec: dict[str, Any]) -> KnowledgeBase:
     """Instantiate a knowledge base from a ``[knowledge_base]`` table."""
     fmt = spec.get("format", "jsonl")
-    path = spec["path"]
     if fmt == "jsonl":
+        path = spec["path"]
         kb = KnowledgeBase.from_jsonl(
             path,
             text_key=spec.get("text_key", "text"),
             id_key=spec.get("id_key", "id"),
         )
     elif fmt == "directory":
+        path = spec["path"]
         kb = KnowledgeBase.from_directory(path, glob=spec.get("glob", "*.txt"))
+    elif fmt == "linkup_fetch":
+        from .knowledge_base.linkup import LinkupWebLoader
+
+        kb = LinkupWebLoader(
+            client=spec.get("client"),
+            render_js=spec.get("render_js", True),
+            include_raw_html=spec.get("include_raw_html", False),
+            extract_images=spec.get("extract_images", False),
+        ).load_urls(spec["urls"], ids=spec.get("ids"))
     else:
         raise ValueError(f"Unsupported knowledge_base.format: {fmt!r}")
 

--- a/linear_adapter_trainer/knowledge_base/__init__.py
+++ b/linear_adapter_trainer/knowledge_base/__init__.py
@@ -5,5 +5,6 @@
 
 from .base import Chunk, KnowledgeBase
 from .chunking import TextSplitter
+from .linkup import LinkupWebLoader
 
-__all__ = ["Chunk", "KnowledgeBase", "TextSplitter"]
+__all__ = ["Chunk", "KnowledgeBase", "LinkupWebLoader", "TextSplitter"]

--- a/linear_adapter_trainer/knowledge_base/linkup.py
+++ b/linear_adapter_trainer/knowledge_base/linkup.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Santander Group
+# SPDX-License-Identifier: Apache-2.0
+
+"""Linkup-powered web ingestion for retrieval knowledge bases."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .base import Chunk, KnowledgeBase
+from .chunking import TextSplitter
+
+
+class LinkupFetchClient(Protocol):
+    """Small subset of the Linkup SDK client used by the loader."""
+
+    def fetch(self, **kwargs: Any) -> Any:
+        """Fetch one URL and return a response with cleaned page content."""
+
+
+@dataclass(slots=True)
+class LinkupWebLoader:
+    """Build a :class:`KnowledgeBase` from pages fetched by Linkup.
+
+    Pass ``client`` in tests or advanced setups. When omitted, the official
+    ``linkup-sdk`` client is imported lazily so the package's offline path stays
+    dependency-light.
+    """
+
+    client: LinkupFetchClient | None = None
+    render_js: bool = True
+    include_raw_html: bool = False
+    extract_images: bool = False
+
+    def load_urls(self, urls: Sequence[str], *, ids: Sequence[str] | None = None) -> KnowledgeBase:
+        """Fetch known URLs and return one knowledge-base chunk per page."""
+        if not urls:
+            raise ValueError("LinkupWebLoader requires at least one URL.")
+        if ids is not None and len(ids) != len(urls):
+            raise ValueError("`ids` length must match `urls` length.")
+
+        client = self._client()
+        chunks: list[Chunk] = []
+        for position, url in enumerate(urls):
+            response = client.fetch(
+                url=url,
+                render_js=self.render_js,
+                include_raw_html=self.include_raw_html,
+                extract_images=self.extract_images,
+            )
+            metadata = {
+                "source": url,
+                "source_url": url,
+                "fetched_with": "linkup",
+                **_extract_metadata(response),
+            }
+            chunks.append(
+                Chunk(
+                    id=str(ids[position]) if ids is not None else f"linkup-{position}",
+                    text=_extract_text(response),
+                    metadata=metadata,
+                )
+            )
+        return KnowledgeBase(chunks)
+
+    def load_and_split_urls(
+        self,
+        urls: Sequence[str],
+        *,
+        ids: Sequence[str] | None = None,
+        splitter: TextSplitter | None = None,
+    ) -> KnowledgeBase:
+        """Fetch known URLs, then split each fetched page into retrieval chunks."""
+        kb = self.load_urls(urls, ids=ids)
+        return (splitter or TextSplitter()).split_knowledge_base(kb)
+
+    def _client(self) -> LinkupFetchClient:
+        if self.client is not None:
+            return self.client
+        try:
+            from linkup import LinkupClient
+        except ImportError as exc:  # pragma: no cover - exercised without dependency
+            raise ImportError(
+                "Linkup web ingestion requires the optional dependency: "
+                "install `linear-adapter-trainer[linkup]` and set `LINKUP_API_KEY`."
+            ) from exc
+        return LinkupClient()
+
+
+def _extract_text(response: Any) -> str:
+    for key in ("content", "markdown", "text"):
+        value = _get_value(response, key)
+        if isinstance(value, str) and value.strip():
+            return value
+    if isinstance(response, str) and response.strip():
+        return response
+    raise ValueError("Linkup fetch response did not contain cleaned page text.")
+
+
+def _extract_metadata(response: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    title = _get_value(response, "title") or _get_value(response, "name")
+    if isinstance(title, str) and title:
+        metadata["title"] = title
+    return metadata
+
+
+def _get_value(response: Any, key: str) -> Any:
+    if isinstance(response, dict):
+        return response.get(key)
+    return getattr(response, key, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,13 @@ sentence-transformers = [
 openai = [
     "openai>=1.40.0",
 ]
+linkup = [
+    "linkup-sdk>=0.18",
+]
 all = [
     "sentence-transformers>=3.0.0",
     "openai>=1.40.0",
+    "linkup-sdk>=0.18",
 ]
 
 [project.urls]

--- a/tests/test_linkup_knowledge_base.py
+++ b/tests/test_linkup_knowledge_base.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Santander Group
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from linear_adapter_trainer.config import build_knowledge_base
+from linear_adapter_trainer.knowledge_base import LinkupWebLoader, TextSplitter
+
+
+class RecordingClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def fetch(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.responses[kwargs["url"]]
+
+
+def test_linkup_loader_fetches_known_urls_into_knowledge_base():
+    client = RecordingClient(
+        {
+            "https://example.com/risk": {
+                "content": "# Risk overview\n\nSource-backed risk text.",
+                "title": "Risk overview",
+            },
+            "https://example.com/governance": {
+                "markdown": "# Governance\n\nClean markdown from Linkup.",
+            },
+        }
+    )
+
+    kb = LinkupWebLoader(client=client).load_urls(
+        ["https://example.com/risk", "https://example.com/governance"],
+        ids=["risk", "governance"],
+    )
+
+    assert kb.ids == ["risk", "governance"]
+    assert kb.get("risk").text == "# Risk overview\n\nSource-backed risk text."
+    assert kb.get("risk").metadata == {
+        "source": "https://example.com/risk",
+        "source_url": "https://example.com/risk",
+        "fetched_with": "linkup",
+        "title": "Risk overview",
+    }
+    assert client.calls == [
+        {
+            "url": "https://example.com/risk",
+            "render_js": True,
+            "include_raw_html": False,
+            "extract_images": False,
+        },
+        {
+            "url": "https://example.com/governance",
+            "render_js": True,
+            "include_raw_html": False,
+            "extract_images": False,
+        },
+    ]
+
+
+def test_linkup_loader_can_split_fetched_pages():
+    client = RecordingClient(
+        {
+            "https://example.com/report": {
+                "content": "First sourced paragraph.\n\nSecond sourced paragraph.\n\nThird sourced paragraph."
+            }
+        }
+    )
+
+    kb = LinkupWebLoader(client=client).load_and_split_urls(
+        ["https://example.com/report"],
+        splitter=TextSplitter(chunk_size=35, chunk_overlap=5),
+    )
+
+    assert len(kb) > 1
+    assert all(chunk.metadata["source_url"] == "https://example.com/report" for chunk in kb)
+    assert all(chunk.metadata["parent_id"] == "linkup-0" for chunk in kb)
+
+
+def test_linkup_loader_requires_optional_dependency_without_client():
+    with pytest.raises(ImportError, match="linear-adapter-trainer\\[linkup\\]"):
+        LinkupWebLoader().load_urls(["https://example.com"])
+
+
+def test_config_builds_linkup_fetch_knowledge_base_with_injected_client():
+    client = RecordingClient(
+        {"https://example.com/docs": {"content": "Trusted source material for an AI workflow."}}
+    )
+
+    kb = build_knowledge_base(
+        {
+            "format": "linkup_fetch",
+            "urls": ["https://example.com/docs"],
+            "client": client,
+            "render_js": False,
+            "chunking": {"enabled": True, "chunk_size": 32, "chunk_overlap": 4},
+        }
+    )
+
+    assert kb.get("linkup-0::0").metadata["source_url"] == "https://example.com/docs"
+    assert client.calls[0]["render_js"] is False


### PR DESCRIPTION
## Summary
- Add an optional `LinkupWebLoader` that turns known public web pages into `KnowledgeBase` chunks for RAG adapter training.
- Keep Linkup as an optional extra (`linear-adapter-trainer[linkup]`) with lazy SDK import and offline fake-client tests.
- Document why clean, sourced, AI-agent-optimized web content helps build trusted retrieval corpora and include a runnable `linkup_fetch` example config.

## Test plan
- `uv run pytest`
- `uv run ruff check .`
- `uv run black --check .`