### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 Santander Group
+# SPDX-License-Identifier: Apache-2.0
+#
+# OpenSSF Scorecard supply-chain security analysis.
+# Runs weekly + on push to main + when branch protection rules change.
+# Results published to scorecard.dev (public dashboard) and uploaded to the
+# repository's Code Scanning view.
+#
+# Like CodeQL, this workflow uploads SARIF results which on private repos
+# requires GitHub Advanced Security. The analyze job is therefore skipped
+# while the repo is private; it activates automatically once flipped to
+# public.
+
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "20 7 * * 2"  # weekly Tuesday 07:20 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write   # required by upload-sarif
+      id-token: write          # required to publish results to scorecard.dev
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to https://api.securityscorecards.dev so the
+          # public dashboard / badge can serve them.
+          publish_results: true
+
+      - name: Upload SARIF as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 14
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds the same pinned OpenSSF Scorecard workflow already running in the other SantanderAI repositories (weekly schedule + push to `main`, SARIF published to code scanning). Closes the monitoring gap for this repo.