### PR TITLE
ci: attach SBOM (SPDX + CycloneDX) to every release

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,36 @@
+# Generates a Software Bill of Materials for each published release and
+# attaches it as release assets in both standard formats (SPDX + CycloneDX).
+# Manual runs (workflow_dispatch) upload the SBOMs as workflow artifacts only.
+name: SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sbom:
+    name: Generate and attach SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # upload release assets
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          format: spdx-json
+          output-file: ${{ github.event.repository.name }}-${{ github.ref_name }}.spdx.json
+          artifact-name: ${{ github.event.repository.name }}-${{ github.ref_name }}.spdx.json
+          upload-release-assets: ${{ github.event_name == 'release' }}
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          format: cyclonedx-json
+          output-file: ${{ github.event.repository.name }}-${{ github.ref_name }}.cdx.json
+          artifact-name: ${{ github.event.repository.name }}-${{ github.ref_name }}.cdx.json
+          upload-release-assets: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
Adds the same SHA-pinned `sbom.yml` already merged and verified in SantanderAI/gen-fraud-graph#28: on every published release it generates a Software Bill of Materials with syft (**SPDX JSON** + **CycloneDX JSON**) and attaches both as release assets; `workflow_dispatch` uploads them as workflow artifacts for verification. Least-privilege permissions (top-level none, `contents: write` at job level).